### PR TITLE
Add docs for OneOf variants

### DIFF
--- a/apps/docs/pages/renderables.md
+++ b/apps/docs/pages/renderables.md
@@ -130,7 +130,59 @@ Unlike `When`, `Ensure` takes a function that returns a renderable. This functio
 
 ### OneOf
 
-For more complicated pattern matching you can use one of the `OneOf` renderables. You generally match on the value of an object field. For that you can use `OneOfField`, `OneOfKind`, or `OneOfType`.
+
+`OneOf` helpers allow matching a signal and rendering a branch based on its
+value.  Several variations exist depending on what you want to match.
+
+```ts
+const status = signal<{ loading: true } | { error: string }>({ loading: true })
+
+OneOf(status, {
+  loading: () => html.div('Loading...'),
+  error: e => html.div('Error:', e)
+})
+```
+
+#### OneOfValue
+
+```ts
+const mode = signal<'view' | 'edit'>('view')
+
+OneOfValue(mode, {
+  view: () => html.div('Viewing'),
+  edit: () => html.div('Editing')
+})
+```
+
+#### OneOfTuple
+
+```ts
+const pair = signal(['A', 1] as ['A' | 'B', number])
+
+OneOfTuple(pair, {
+  A: n => html.div('A:', n.map(String)),
+  B: n => html.div('B:', n.map(String))
+})
+```
+
+#### OneOfField
+
+```ts
+type State =
+  | { state: 'loading' }
+  | { state: 'error', message: string }
+  | { state: 'ready', content: string }
+
+const state = signal<State>({ state: 'loading' })
+
+OneOfField(state, 'state', {
+  loading: () => html.div('Loading...'),
+  error: s => html.div('Error:', s.$.message),
+  ready: s => html.div('Ready:', s.$.content)
+})
+```
+
+#### OneOfKind
 
 ```ts
 type MyType = { kind: 'A', text: string } | { kind: 'B', value: number }
@@ -138,8 +190,21 @@ type MyType = { kind: 'A', text: string } | { kind: 'B', value: number }
 const valueSignal = signal<MyType>({ kind: 'A', text: 'Hello, World!' })
 
 OneOfKind(valueSignal, {
-  A: v => html.div('A: ', v.$.text),
-  B: v => html.div('B: ', v.$.value.map(String))
+  A: v => html.div('A:', v.$.text),
+  B: v => html.div('B:', v.$.value.map(String))
+})
+```
+
+#### OneOfType
+
+```ts
+type Msg = { type: 'inc', value: number } | { type: 'dec', value: number }
+
+const msg = signal<Msg>({ type: 'inc', value: 1 })
+
+OneOfType(msg, {
+  inc: m => html.div('Inc', m.$.value.map(String)),
+  dec: m => html.div('Dec', m.$.value.map(String))
 })
 ```
 

--- a/packages/tempots-dom/test/oneof.spec.ts
+++ b/packages/tempots-dom/test/oneof.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
-import { prop, render, html, WithElement, OneOfType } from "../src";
+import { prop, render, html, WithElement, OneOf, OneOfType, OneOfValue, OneOfTuple, OneOfField, OneOfKind } from "../src";
 import { sleep } from "./helper";
 const { div } = html
 
@@ -16,6 +16,9 @@ export interface B {
 export type Letter = A | B
 
 describe("OneOf", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
   test("type", async () => {
     const p = prop<Letter>({ type: "A", text: "a" });
     const spyMountA = vi.fn()
@@ -59,4 +62,89 @@ describe("OneOf", () => {
     expect(spyMountB).toBeCalledTimes(1)
     expect(document.body.innerHTML).toStrictEqual('<div>c</div>');
   });
+
+  test("value", async () => {
+    const mode = prop<'view' | 'edit'>('view')
+    render(
+      OneOfValue(mode, {
+        view: () => div('Viewing'),
+        edit: () => div('Editing')
+      }),
+      document.body
+    )
+    expect(document.body.innerHTML).toStrictEqual('<div>Viewing</div>')
+    mode.set('edit')
+    await sleep()
+    expect(document.body.innerHTML).toStrictEqual('<div>Editing</div>')
+  })
+
+  test("tuple", async () => {
+    const pair = prop(['A', 1] as ['A' | 'B', number])
+    render(
+      OneOfTuple(pair, {
+        A: n => div('A:', n.map(String)),
+        B: n => div('B:', n.map(String))
+      }),
+      document.body
+    )
+    expect(document.body.innerHTML).toStrictEqual('<div>A:1</div>')
+    pair.set(['B', 2])
+    await sleep()
+    expect(document.body.innerHTML).toStrictEqual('<div>B:2</div>')
+  })
+
+  test("field", async () => {
+    type State =
+      | { state: 'loading' }
+      | { state: 'error', message: string }
+      | { state: 'ready', content: string }
+    const state = prop<State>({ state: 'loading' })
+    render(
+      OneOfField(state, 'state', {
+        loading: () => div('Loading...'),
+        error: s => div('Error:', s.$.message),
+        ready: s => div('Ready:', s.$.content)
+      }),
+      document.body
+    )
+    expect(document.body.innerHTML).toStrictEqual('<div>Loading...</div>')
+    state.set({ state: 'ready', content: 'Ok' })
+    await sleep()
+    expect(document.body.innerHTML).toStrictEqual('<div>Ready:Ok</div>')
+    state.set({ state: 'error', message: 'Oops' })
+    await sleep()
+    expect(document.body.innerHTML).toStrictEqual('<div>Error:Oops</div>')
+  })
+
+  test("kind", async () => {
+    type MyType = { kind: 'A', text: string } | { kind: 'B', value: number }
+    const value = prop<MyType>({ kind: 'A', text: 'Hello, World!' })
+    render(
+      OneOfKind(value, {
+        A: v => div('A:', v.$.text),
+        B: v => div('B:', v.$.value.map(String))
+      }),
+      document.body
+    )
+    expect(document.body.innerHTML).toStrictEqual('<div>A:Hello, World!</div>')
+    value.set({ kind: 'B', value: 5 })
+    await sleep()
+    expect(document.body.innerHTML).toStrictEqual('<div>B:5</div>')
+  })
+
+  test("oneof", async () => {
+    type Status = { loading: true } | { error: string }
+    const status = prop<Status>({ loading: true })
+    render(
+      OneOf(status, {
+        loading: () => div('Loading...'),
+        error: e => div('Error:', e)
+      }),
+      document.body
+    )
+    expect(document.body.innerHTML).toStrictEqual('<div>Loading...</div>')
+    status.set({ error: 'Oops' })
+    await sleep()
+    expect(document.body.innerHTML).toStrictEqual('<div>Error:Oops</div>')
+  })
 });


### PR DESCRIPTION
## Summary
- document OneOf variants with code samples
- add tests for OneOf variants

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6850a1cbfac0832db7128261c7d397d8