### PR TITLE
Fix memory leak in Repeat renderable

### DIFF
--- a/packages/tempots-dom/src/renderable/repeat.ts
+++ b/packages/tempots-dom/src/renderable/repeat.ts
@@ -88,7 +88,7 @@ export const Repeat = (
         pos.total.map(v => v - 1)
       )
       return Fragment(
-        OnDispose(sepPos.dispose),
+        OnDispose(sepPos.dispose, pos.dispose),
         renderableOfTNode(element(pos)),
         When(
           pos.isLast,
@@ -110,7 +110,12 @@ export const Repeat = (
           }
           for (let i = clears.length; i < newLength; i++) {
             const pos = new ElementPosition(i, times)
-            clears.push(renderableOfTNode(element(pos))(newCtx))
+            clears.push(
+              Fragment(
+                OnDispose(pos.dispose),
+                renderableOfTNode(element(pos))
+              )(newCtx)
+            )
           }
         })
 
@@ -125,9 +130,13 @@ export const Repeat = (
       }
     } else {
       return Fragment(
-        ...Array.from({ length: times }, (_, i) => i).map(i =>
-          renderableOfTNode(element(new ElementPosition(i, signal(times))))
-        )
+        ...Array.from({ length: times }, (_, i) => i).map(i => {
+          const pos = new ElementPosition(i, signal(times))
+          return Fragment(
+            OnDispose(pos.dispose),
+            renderableOfTNode(element(pos))
+          )
+        })
       )
     }
   }

--- a/packages/tempots-dom/src/std/element-position.ts
+++ b/packages/tempots-dom/src/std/element-position.ts
@@ -60,6 +60,7 @@ export class ElementPosition {
   }
 
   readonly dispose = () => {
-    this.total.dispose()
+    this.#lastSignal?.dispose()
+    this.#lastSignal = undefined
   }
 }


### PR DESCRIPTION
## Summary
- avoid disposing shared `times` signal in `ElementPosition`
- clean up `isLast` watchers when repeated nodes are removed

## Testing
- `pnpm -F @tempots/dom test`
- `pnpm -F @tempots/std test`
- `pnpm -F @tempots/ui build`
- `pnpm -F @tempots/dom build`
- `pnpm -F @tempots/std build`
- `pnpm -F @tempots/ui test`


------
https://chatgpt.com/codex/tasks/task_e_6850fc2f24c8832d8203f9d0e3c70744