### PR TITLE
Standardize equality helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,16 @@ git commit -m "docs: update README with new examples"
 - Prefer explicit types over `any`
 - Use JSDoc comments for public APIs
 - Follow existing naming conventions
+#### Equality terminology
+
+Use the following naming scheme for equality related features:
+
+- **equal** – For modules and standalone functions that perform equality checks. Example: `strictEqual`, `deepEqual`.
+- **equals** – For parameters or properties that accept an equality function. Example: `signal(value, equals)`.
+- **equality** – Use in documentation when referring to the concept or a custom equality function.
+
+Keeping these terms consistent improves readability across the project.
+
 
 ### Formatting
 

--- a/packages/tempots-std/src/array.ts
+++ b/packages/tempots-std/src/array.ts
@@ -131,19 +131,19 @@ export const arrayTail = <A>(arr: A[]): A[] => arr.slice(1)
  * @typeParam T - The type of elements in the arrays.
  * @param a - The first array.
  * @param b - The second array.
- * @param equality - The custom equality function to compare elements.
+ * @param equals - The custom equality function to compare elements.
  * @returns Returns `true` if the arrays are equal, `false` otherwise.
  * @public
  */
 export const areArraysEqual = <T>(
   a: T[],
   b: T[],
-  equality: (a: T, b: T) => boolean
+  equals: (a: T, b: T) => boolean
 ): boolean => {
   if (a.length !== b.length) return false
   else {
     for (let i = 0; i < a.length; i++) {
-      if (!equality(a[i], b[i])) return false
+      if (!equals(a[i], b[i])) return false
     }
     return true
   }

--- a/packages/tempots-std/src/number.ts
+++ b/packages/tempots-std/src/number.ts
@@ -313,7 +313,7 @@ export const interpolateAngleCCW = (
 
 /**
  * number numbers can sometime introduce tiny errors even for simple operations.
- * `nearEquals` compares two floats using a tiny tollerance (last optional
+ * `nearEqual` compares two floats using a tiny tollerance (last optional
  * argument). By default it is defined as `EPSILON`.
  *
  * @param a - The first number to compare.
@@ -323,12 +323,12 @@ export const interpolateAngleCCW = (
  * @public
  * @example
  * ```ts
- * nearEquals(5, 5.000000000000001) // returns true
- * nearEquals(5, 5.000000000001) // returns false
- * nearEquals(5, 5.000000000001, 1e-9) // returns true
+ * nearEqual(5, 5.000000000000001) // returns true
+ * nearEqual(5, 5.000000000001) // returns false
+ * nearEqual(5, 5.000000000001, 1e-9) // returns true
  * ```
  **/
-export const nearEquals = (
+export const nearEqual = (
   a: number,
   b: number,
   tollerance = EPSILON

--- a/packages/tempots-ui/src/renderables/size.ts
+++ b/packages/tempots-ui/src/renderables/size.ts
@@ -10,7 +10,7 @@ import {
   getWindow,
   OnDispose,
 } from '@tempots/dom'
-import { nearEquals } from '@tempots/std'
+import { nearEqual } from '@tempots/std'
 
 /**
  * Represents a rectangle with position and dimensions.
@@ -195,10 +195,10 @@ export class Rect {
    */
   readonly equals = (other: Rect) => {
     return (
-      nearEquals(this.left, other.left) &&
-      nearEquals(this.top, other.top) &&
-      nearEquals(this.width, other.width) &&
-      nearEquals(this.height, other.height)
+      nearEqual(this.left, other.left) &&
+      nearEqual(this.top, other.top) &&
+      nearEqual(this.width, other.width) &&
+      nearEqual(this.height, other.height)
     )
   }
 }


### PR DESCRIPTION
## Summary
- rename `nearEquals` helper to `nearEqual`
- update `Rect.equals` usage to match
- rename `equality` argument to `equals` in array utilities

## Testing
- `pnpm test` *(fails: Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_6852dcb2238c832dab1c5d7caa0621c0